### PR TITLE
feat(flake.nix): init flake.{nix, lock}.

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,25 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1695318763,
+        "narHash": "sha256-FHVPDRP2AfvsxAdc+AsgFJevMz5VBmnZglFUMlxBkcY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e12483116b3b51a185a33a272bf351e357ba9a99",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,19 @@
+{
+  description = "A very basic flake";
+
+  outputs = {
+    self,
+    nixpkgs,
+  }: let
+    buildInputs = [];
+    nativeBuildInputs = [pkgs.rustc pkgs.cargo];
+    pkgs = import nixpkgs {system = "x86_64-linux";};
+  in {
+    devShells.x86_64-linux.default = pkgs.mkShell {
+      packages = [
+        pkgs.rust-analyzer
+      ];
+      inherit buildInputs nativeBuildInputs;
+    };
+  };
+}


### PR DESCRIPTION
This includes a basic development shell for programming on linux. NOTE: This can support macos, as well as other linux systems that aren't x86_64-linux (like arm). It could also support building the project itself, but this commit includes nothing beyond a basic way to setup a devenv on linux.