### PR TITLE
fix(process): `assert` should check if arrival time is before, or at

### DIFF
--- a/src/process.rs
+++ b/src/process.rs
@@ -19,7 +19,7 @@ impl Process {
         }
     }
     pub fn tick(&mut self, state: &SystemState) {
-        assert!(self.arrival >= state.time);
+        assert!(self.arrival <= state.time);
         self.burst -= 1;
     }
 }


### PR DESCRIPTION
current system time before ticking().

As an aside, it might be nice if this function returned an error instead of panicing when this isn't true. Something like:
```
enum FailedToTick {
    HasntArrived,
    AlreadyFinished,
}

Result<i32, FailedToTick>

```
depends on: #1 