### PR TITLE
Feat/fcfs scheduler

### DIFF
--- a/src/process.rs
+++ b/src/process.rs
@@ -1,10 +1,11 @@
 use crate::system_state::SystemState;
 
+#[derive(Debug)]
 pub struct Process{
     name: String,
     pid: i32,
     priority: i32,
-    burst: i32,
+    pub burst: i32,
     pub arrival: i32,
 }
 

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -61,4 +61,56 @@ mod tests {
         sched.tick();
         assert_eq!(sched.system_state.time, 1);
     }
+    #[test]
+    fn test_fcfs_one_process() {
+        let mut sched = super::FCFS::new(vec![Process::new(String::from("test"), 0, 0, 10, 0)]);
+        for _ in 0..10 {
+            sched.tick();
+        }
+        assert_eq!(sched.finished.len(), 1);
+    }
+    #[test]
+    fn test_fcfs_one_process_different_arrival_time() {
+        let mut sched = super::FCFS::new(vec![Process::new(String::from("test"), 0, 0, 10, 2)]);
+        for _ in 0..10 {
+            sched.tick();
+        }
+        assert_eq!(sched.processes[0].burst, 2);
+        for _ in 0..2 {
+            sched.tick();
+        }
+        assert_eq!(sched.finished.len(), 1);
+    }
+    #[test]
+    fn test_fcfs_multiple_processes() {
+        let mut sched = super::FCFS::new(vec![
+            Process::new(String::from("test"), 0, 0, 10, 0),
+            Process::new(String::from("test2"), 1, 1, 7, 5),
+        ]);
+        for _ in 0..10 {
+            sched.tick();
+        }
+        assert_eq!(sched.finished.len(), 1);
+        for _ in 0..7 {
+            sched.tick();
+        }
+        assert_eq!(sched.finished.len(), 2);
+    }
+    #[test]
+    fn test_fcfs_multiple_processes_with_idle() {
+        let mut sched = super::FCFS::new(vec![
+            Process::new(String::from("test"), 0, 0, 10, 0),
+            Process::new(String::from("test2"), 1, 1, 7, 11),
+        ]);
+        for _ in 0..10 {
+            sched.tick();
+        }
+        assert_eq!(sched.finished.len(), 1);
+        for _ in 0..7 {
+            sched.tick();
+        }
+        assert_eq!(sched.finished.len(), 1);
+        sched.tick();
+        assert_eq!(sched.finished.len(), 2);
+    }
 }

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -1,8 +1,14 @@
+use std::collections::VecDeque;
+
 use crate::system_state::SystemState;
 use crate::process::Process;
 
 struct FCFS {
-    processes: Vec<Process>,
+    // FCFS is a FIFO algorithm. It takes processes by arrival time,
+    // and processes the ones that came in first. A VecDeque,
+    // which can function as a queue (or a stack, it has both pop_{front, back} methods)
+    // is nice for this.
+    processes: VecDeque<Process>,
     system_state: SystemState,
 }
 
@@ -10,7 +16,8 @@ impl FCFS {
     pub fn new(mut processes: Vec<Process>) -> Self {
         processes.sort_by(|a,b| a.arrival.cmp(&b.arrival));
         Self {
-            processes,system_state: SystemState::new(),
+            processes: processes.into(),
+            system_state: SystemState::new(),
         }
     }
 }

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -9,6 +9,7 @@ struct FCFS {
     // which can function as a queue (or a stack, it has both pop_{front, back} methods)
     // is nice for this.
     processes: VecDeque<Process>,
+    finished: Vec<Process>,
     system_state: SystemState,
 }
 
@@ -18,6 +19,7 @@ impl FCFS {
         Self {
             processes: processes.into(),
             system_state: SystemState::new(),
+            finished: Vec::new(),
         }
     }
 }
@@ -36,6 +38,12 @@ impl Scheduler for FCFS {
             return;
         }
         process.tick(&self.system_state);
+        if process.burst == 0 {
+            // we've been working with the first process this entire time -
+            // we know it exists so it's safe to just `unwrap()` it rather
+            // then checking if it's there or not.
+            self.finished.push(self.processes.pop_front().unwrap());
+        }
         self.system_state.time += 1;
     }
 }

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -21,9 +21,14 @@ impl Scheduler for FCFS {
             Some(v) => v,
             None => { self.system_state.time += 1; return;},
         };
-        if process.arrival <= self.system_state.time {
-            process.tick(&self.system_state);
+        // if the next process to work on isn't ready yet -
+        // increment the system time and return, since we
+        // don't have anything to do.
+        if process.arrival > self.system_state.time {
+            self.system_state.time += 1;
+            return;
         }
+        process.tick(&self.system_state);
         self.system_state.time += 1;
     }
 }


### PR DESCRIPTION
This PR finishes up the FCFS scheduler. In the process of implementing this, I noticed some APIs we may want to improve:

- Process.tick() should probably return a Result, with it's cpu burst time as success case, and cause of failure for the error. (ex. process is already finished running, process hasn't arrived yet).
- `SystemState` shouldn't be stored in the scheduler, but rather should get a ref. whenever it needs it in e.g. `tick()`. The caller should be in charge of incrementing the time every time tick() is called for example. This would help clean up the code a lot since you'd only have to change the system_time in one spot: the caller, rather then every code path in `tick()`. Another reason for this is that when we add other schedulers, they'll need a ref. to SystemState too and despite both `tick`'ing, time should only go up by 1 unit.

Not sure if I should add those changes to this PR?

depends on: #4 