### PR TITLE
feat(scheduler): add `get_queue` method to Scheduler trait.

### DIFF
--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -17,5 +17,6 @@ pub enum SchedulerResult<'a> {
 pub trait Scheduler {
     fn tick(&mut self, system_state: &SystemState) -> SchedulerResult;
     fn enqueue(&mut self, proc: Process);
+    fn get_queue(&self) -> Vec<&Process>;
 }
 

--- a/src/scheduler/fcfs.rs
+++ b/src/scheduler/fcfs.rs
@@ -24,6 +24,9 @@ impl FCFS {
 }
 
 impl Scheduler for FCFS {
+    fn get_queue(&self) -> Vec<&Process> {
+        self.processes.iter().collect()
+    }
 
     fn tick(&mut self, system_state: &SystemState) -> SchedulerResult<'_> {
        let process = match self.processes.front_mut() {


### PR DESCRIPTION
This is going to be used so the driver can see the different processes in the queue.